### PR TITLE
Add previous job results to JobCtx in case a job needs the results from the previous job in the chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ if err != nil {
 }
 ```
 
+#### Getting results of previous job in a chain
+A job in the chain can access the results of the previous job in the chain by getting `JobCtx.Meta.PrevJobResults`. This will contain any job result saved by the previous job by `JobCtx.Save()`. 
+
 #### Getting a chain message 
 To query the details of a chain that was enqueued, we can use `srv.GetChain`. It returns a `ChainMessage` which contains details related to a chian. 
 

--- a/jobs.go
+++ b/jobs.go
@@ -45,6 +45,21 @@ type Meta struct {
 	Retried       uint32
 	PrevErr       string
 	ProcessedAt   time.Time
+
+	// PrevJobResults contains any job results set by a previous job in a chain.
+	// This will be nil if the previous job doesn't set the results on JobCtx.
+	PrevJobResults []byte
+}
+
+// DefaultMeta returns Meta with a UUID and other defaults filled in.
+func DefaultMeta(opts JobOpts) Meta {
+	return Meta{
+		UUID:     uuid.NewString(),
+		Status:   StatusStarted,
+		MaxRetry: opts.MaxRetries,
+		Schedule: opts.Schedule,
+		Queue:    opts.Queue,
+	}
 }
 
 // NewJob returns a job with arbitrary payload.
@@ -67,12 +82,17 @@ func NewJob(handler string, payload []byte, opts JobOpts) (Job, error) {
 // JobCtx is passed onto handler functions. It allows access to a job's meta information to the handler.
 type JobCtx struct {
 	store Results
-	Meta  Meta
+	// results just holds the results set by calling Save().
+	results []byte
+	Meta    Meta
 }
 
 // Save() sets arbitrary results for a job on the results store.
 func (c *JobCtx) Save(b []byte) error {
 	// TODO: Maybe recieve context in Save()
+	// Store saved in the job ctx as well to easily get the result instead of
+	// going to the broker every time.
+	c.results = b
 	return c.store.Set(context.Background(), resultsPrefix+c.Meta.UUID, b)
 }
 
@@ -84,16 +104,10 @@ type JobMessage struct {
 }
 
 // message() converts a task into a TaskMessage, ready to be enqueued onto the broker.
-func (t *Job) message() JobMessage {
+func (t *Job) message(meta Meta) JobMessage {
 	return JobMessage{
-		Meta: Meta{
-			UUID:     uuid.NewString(),
-			Status:   StatusStarted,
-			MaxRetry: t.opts.MaxRetries,
-			Schedule: t.opts.Schedule,
-			Queue:    t.opts.Queue,
-		},
-		Job: t,
+		Meta: meta,
+		Job:  t,
 	}
 }
 
@@ -103,8 +117,12 @@ func (t *Job) message() JobMessage {
 // 2. Sets the job status as "started" on the results store.
 // 3. Enqueues the job (if the job is scheduled, pushes it onto the scheduler)
 func (s *Server) Enqueue(ctx context.Context, t Job) (string, error) {
+	return s.enqueueWithMeta(ctx, t, DefaultMeta(t.opts))
+}
+
+func (s *Server) enqueueWithMeta(ctx context.Context, t Job, meta Meta) (string, error) {
 	var (
-		msg = t.message()
+		msg = t.message(meta)
 	)
 
 	// Set job status in the results backend.


### PR DESCRIPTION
This PR adds `PrevJobResults` to `Meta` which is passed to the next job in a chain.

Also I have modified the `Enqueue` method to use added `enqueueWithMeta` method. This was we can modify the meta and still reuse the function. Let me know if this looks good or any changes you think are needed.