### PR TITLE
fix: Fix msgpack decoding in GetResult.

### DIFF
--- a/server.go
+++ b/server.go
@@ -126,7 +126,7 @@ func (s *Server) GetResult(ctx context.Context, uuid string) ([][]byte, error) {
 	}
 
 	var d [][]byte
-	if err := msgpack.Unmarshal(b, d); err != nil {
+	if err := msgpack.Unmarshal(b, &d); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes a bug where msgpack decoding fails because a non-pointer is given instead of a pointer.