### PR TITLE
feat: Add timeout to jobs.

### DIFF
--- a/chains_test.go
+++ b/chains_test.go
@@ -12,7 +12,7 @@ const chainTask = "chain-task"
 func TestEnqueueChain(t *testing.T) {
 	var (
 		ctx   = context.Background()
-		srv   = newServer(t)
+		srv   = newServer(t, taskName, MockHandler)
 		chain = makeChain(t, taskName, false, false)
 	)
 	go srv.Start(ctx)
@@ -43,7 +43,7 @@ func TestGetChain(t *testing.T) {
 
 			return nil
 		}
-		srv = newServer(t)
+		srv = newServer(t, taskName, MockHandler)
 		ctx = context.Background()
 	)
 

--- a/groups_test.go
+++ b/groups_test.go
@@ -9,7 +9,7 @@ import (
 func TestEnqueueGroup(t *testing.T) {
 	var (
 		ctx   = context.Background()
-		srv   = newServer(t)
+		srv   = newServer(t, taskName, MockHandler)
 		group = makeGroup(t, false, false)
 	)
 	go srv.Start(ctx)
@@ -28,7 +28,7 @@ func TestGetGroup(t *testing.T) {
 			StatusDone:   makeGroup(t, false, false),
 			StatusFailed: makeGroup(t, true, true),
 		}
-		srv = newServer(t)
+		srv = newServer(t, taskName, MockHandler)
 		ctx = context.Background()
 	)
 	go srv.Start(ctx)

--- a/jobs.go
+++ b/jobs.go
@@ -34,6 +34,7 @@ type JobOpts struct {
 	Queue      string
 	MaxRetries uint32
 	Schedule   string
+	Timeout    time.Duration
 }
 
 // Meta contains fields related to a job. These are updated when a task is consumed.
@@ -80,6 +81,7 @@ func NewJob(handler string, payload []byte, opts JobOpts) (Job, error) {
 
 // JobCtx is passed onto handler functions. It allows access to a job's meta information to the handler.
 type JobCtx struct {
+	context.Context
 	store Results
 	// results just holds the results set by calling Save().
 	results [][]byte
@@ -94,7 +96,9 @@ func (c *JobCtx) Save(b []byte) error {
 		return err
 	}
 
-	return c.store.Set(context.Background(), resultsPrefix+c.Meta.UUID, d)
+	fmt.Println("saving results..", d)
+
+	return c.store.Set(c, resultsPrefix+c.Meta.UUID, d)
 }
 
 // JobMessage is a wrapper over Task, used to transport the task over a broker.

--- a/jobs.go
+++ b/jobs.go
@@ -96,8 +96,6 @@ func (c *JobCtx) Save(b []byte) error {
 		return err
 	}
 
-	fmt.Println("saving results..", d)
-
 	return c.store.Set(c, resultsPrefix+c.Meta.UUID, d)
 }
 

--- a/server.go
+++ b/server.go
@@ -244,7 +244,7 @@ func (s *Server) execJob(ctx context.Context, msg JobMessage, task Task) error {
 	taskCtx := JobCtx{Meta: msg.Meta, store: s.results}
 	var (
 		// errChan is to receive the error returned by the handler.
-		errChan chan error
+		errChan = make(chan error, 1)
 		err     error
 
 		// jctx is the context passed to the job.
@@ -253,7 +253,7 @@ func (s *Server) execJob(ctx context.Context, msg JobMessage, task Task) error {
 
 	// If there is a deadline given, set that on jctx and not ctx
 	// because we don't want to cancel the entire context in case deadline exceeded.
-	if !(msg.Job.Opts.Timeout.Seconds() == 0) {
+	if !(msg.Job.Opts.Timeout == 0) {
 		jctx, cancelFunc = context.WithDeadline(ctx, time.Now().Add(msg.Job.Opts.Timeout))
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/zerodha/logf"
 
@@ -16,7 +17,7 @@ const (
 	taskName = "mock_handler"
 )
 
-func newServer(t *testing.T) *Server {
+func newServer(t *testing.T, taskName string, handler func([]byte, JobCtx) error) *Server {
 	lo := logf.New(logf.Opts{
 		Level: logf.DebugLevel,
 	})
@@ -28,7 +29,7 @@ func newServer(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv.RegisterTask(taskName, MockHandler, TaskOpts{
+	srv.RegisterTask(taskName, handler, TaskOpts{
 		Concurrency: 5,
 	})
 
@@ -48,6 +49,13 @@ func MockHandler(msg []byte, _ JobCtx) error {
 	if m.ShouldErr {
 		return fmt.Errorf("task ended with error")
 	}
+
+	return nil
+}
+
+// MockHandlerWithSleep is a mock handler that sleeps for a long time.
+func MockHandlerWithSleep(msg []byte, _ JobCtx) error {
+	time.Sleep(3000 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
After the timeout, the job will be marked as failed and will be retried if it has to.

Also this makes `JobCtx` as a `context.Context`, which the processors can now depend on.