### PR TITLE
fix: Initialize queue in in-memory broker if the queue isn't found in Consume

### DIFF
--- a/brokers/in-memory/broker.go
+++ b/brokers/in-memory/broker.go
@@ -24,8 +24,17 @@ func New() *Broker {
 
 func (r *Broker) Consume(ctx context.Context, work chan []byte, queue string) {
 	r.mu.RLock()
-	ch := r.queues[queue]
+	ch, ok := r.queues[queue]
 	r.mu.RUnlock()
+
+	// If the queue isn't found, make a queue.
+	if !ok {
+		ch = make(chan []byte, 100)
+		r.mu.Lock()
+		r.queues[queue] = ch
+		r.mu.Unlock()
+
+	}
 
 	for {
 		select {

--- a/brokers/in-memory/broker.go
+++ b/brokers/in-memory/broker.go
@@ -46,9 +46,7 @@ func (r *Broker) Consume(ctx context.Context, work chan []byte, queue string) {
 			r.pending[queue] = r.pending[queue][1:]
 			r.pmu.Unlock()
 
-			r.mu.RLock()
 			work <- d
-			r.mu.RUnlock()
 		}
 	}
 }


### PR DESCRIPTION
This fixes multi queue consume in in-memory broker.

Also fixes the race condition when Enqueue isn't called immediately after Consume.