### PR TITLE
feat: Add OnError and OnSuccess to a Job.

### DIFF
--- a/brokers/in-memory/broker.go
+++ b/brokers/in-memory/broker.go
@@ -27,13 +27,11 @@ func (r *Broker) Consume(ctx context.Context, work chan []byte, queue string) {
 	ch, ok := r.queues[queue]
 	r.mu.RUnlock()
 
-	// If the queue isn't found, make a queue.
 	if !ok {
 		ch = make(chan []byte, 100)
 		r.mu.Lock()
 		r.queues[queue] = ch
 		r.mu.Unlock()
-
 	}
 
 	for {

--- a/chains.go
+++ b/chains.go
@@ -46,7 +46,7 @@ func NewChain(j []Job, opts ChainOpts) (Chain, error) {
 	// Set the on success tasks as the i+1 task,
 	// hence forming a "chain" of tasks.
 	for i := 0; i < len(j)-1; i++ {
-		j[i].OnSuccess = &j[i+1]
+		j[i].OnSuccess = append(j[i].OnSuccess, &j[i+1])
 	}
 
 	return Chain{Jobs: j, Opts: opts}, nil
@@ -114,10 +114,10 @@ checkJobs:
 	// to success. Otherwise update the current job and perform all the above checks.
 	case StatusDone:
 		c.PrevJobs = append(c.PrevJobs, currJob.ID)
-		if currJob.OnSuccessID == "" {
+		if len(currJob.OnSuccessIDs) == 0 {
 			c.Status = StatusDone
 		} else {
-			currJob, err = s.GetJob(ctx, currJob.OnSuccessID)
+			currJob, err = s.GetJob(ctx, currJob.OnSuccessIDs[0])
 			if err != nil {
 				return ChainMessage{}, nil
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -16,11 +17,13 @@ const (
 )
 
 func newServer(t *testing.T, taskName string, handler func([]byte, JobCtx) error) *Server {
-	lo := slog.Default().Handler()
+	lo := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	}))
 	srv, err := NewServer(ServerOpts{
 		Broker:  rb.New(),
 		Results: rr.New(),
-		Logger:  lo,
+		Logger:  lo.Handler(),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We can now enqueue tasks when either job succeeds or fails.

Chains now used the `OnSuccess` slice to add the next jobs.